### PR TITLE
Fix onPageScrolled  mSelectedTab values not equals mViewPager.getCurrentItem

### DIFF
--- a/TabBarViewLibrary/src/com/mirko/tbv/TabBarView.java
+++ b/TabBarViewLibrary/src/com/mirko/tbv/TabBarView.java
@@ -181,20 +181,6 @@ public class TabBarView extends LinearLayout {
 				
 			}
 		}
-		
-		getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
-
-			@SuppressLint("NewApi")
-			@Override
-			public void onGlobalLayout() {
-				
-				getViewTreeObserver().removeOnGlobalLayoutListener(this);
-
-				mSelectedTab = pager.getCurrentItem();
-				
-			}
-		});
-
 	}
 
 	private void addTabViewL(final int i, String string, int pageIconResId) {


### PR DESCRIPTION
fix in some devices, mSelectedTab from OnPagerListener onPageScrolled method is not equals  mViewPager.getCurrentItem()
